### PR TITLE
Drop Node <6 and bump request version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - '0.10'
+  - 6
+  - 8

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Web scraping and HTML-reprocessing. The easy way.",
   "version": "1.0.4",
   "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
-  "homepage" : "http://inikulin.github.io/ineed/",
+  "homepage": "http://inikulin.github.io/ineed/",
   "dependencies": {
     "parse5": "1.2.0",
-    "request": "2.40.0"
+    "request": "2.88.0"
   },
   "devDependencies": {
     "should": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "scripts": {
     "test": "node test/run_tests.js"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
This squashes a whooooole lot of deprecation and security warnings. Test suite passes OK.